### PR TITLE
Fix newline handling in FileTool insert

### DIFF
--- a/agent demo/tests/test_file_tool_insert.py
+++ b/agent demo/tests/test_file_tool_insert.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from tools.file_tool import FileTool
+
+
+def test_insert_preserves_newlines(tmp_path):
+    file_tool = FileTool()
+    test_file = tmp_path / "test.txt"
+    file_tool.run({"operation": "write", "path": str(test_file), "content": "a\nb\n"})
+
+    file_tool._insert(test_file, 1, "x\ny")
+
+    with open(test_file, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    assert lines == ["a\n", "x\n", "y\n", "b\n"]

--- a/agent demo/tools/file_tool.py
+++ b/agent demo/tools/file_tool.py
@@ -332,8 +332,8 @@ class FileTool(Tool):
         # Save history
         self._file_history[path].append("".join(lines))
 
-        # Insert the new content
-        new_lines = new_str.split("\n")
+        # Insert the new content with newline characters preserved
+        new_lines = [ln + "\n" for ln in new_str.splitlines()]
         lines[insert_line:insert_line] = new_lines
 
         with open(path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- fix inserting lines without newline characters in `FileTool._insert`
- add regression test for `_insert` newline behavior

## Testing
- `pytest 'agent demo/tests/test_file_tool_insert.py' -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b071e6f8832a843b1a2ab5aed9e2